### PR TITLE
Update resolvers.ts

### DIFF
--- a/src/decorators/resolvers.ts
+++ b/src/decorators/resolvers.ts
@@ -1,4 +1,4 @@
-import { Sequelize } from 'sequelize/types';
+import { Sequelize } from 'sequelize';
 
 export const DEFAULT_RESOLVER = (functionName: string, args: any[]): Sequelize => {
   const sequelize = args.find((a) => a instanceof Sequelize);


### PR DESCRIPTION
Fix runtime issue for newer versions of Sequelize.

```
Error: Package subpath './types' is not defined by "exports" in /usr/src/app/node_modules/sequelize/package.json
 at new NodeError (node:internal/errors:405:5)
at exportsNotFound (node:internal/modules/esm/resolve:359:10)
 at packageExportsResolve (node:internal/modules/esm/resolve:695:9)
 at resolveExports (node:internal/modules/cjs/loader:567:36)
 at Function.Module._findPath (node:internal/modules/cjs/loader:636:31)
 at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1063:27)
 at Function.Module._load (node:internal/modules/cjs/loader:922:27)
 at Module.require (node:internal/modules/cjs/loader:1143:19)
 at require (node:internal/modules/cjs/helpers:121:18)
 at Object.<anonymous> 
 (/usr/src/app/node_modules/zb-sequelize/src/decorators/resolvers.ts:1:1)
 ```